### PR TITLE
bump velero/velero chart to version v2.13.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource helm_release this {
   recreate_pods = lookup(var.app, "recreate_pods", true)
   max_history   = lookup(var.app, "max_history", 1)
   lint          = lookup(var.app, "lint", true)
-  version       = lookup(var.app, "version", "2.12.0")
+  version       = lookup(var.app, "version", "2.13.2")
 
   values = concat(var.values, list(<<EOF
 serviceAccount:


### PR DESCRIPTION
`velero/velero:v2.12.0` fails helm chart lint with the following errors:

```
Error: malformed chart or values:
	templates/crds/backups.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/backupstoragelocations.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/cleanup-crds.yaml: object name does not conform to Kubernetes naming requirements: "": invalid metadata name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not longer than 253
	templates/crds/deletebackuprequests.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/downloadrequests.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/podvolumebackups.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/podvolumerestores.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/resticrepositories.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/restores.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/schedules.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/serverstatusrequests.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
	templates/crds/volumesnapshotlocations.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
```