### PR TITLE
Refactor usage of deprecated `list` function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -17,7 +17,7 @@ repos:
   - id: detect-aws-credentials
     args: ['--allow-missing-credentials']
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.31.0
+  rev: v1.50.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.38.0"
+  hashes = [
+    "h1:qKEjN/EM56XT46vGY33eoq7nD6JuGqRqFp7tkzTrRM0=",
+    "zh:20476d4c1b0c0efc55226bcbd85fbd948638fd9860a0edcdb7875cbb2b449e46",
+    "zh:7102622e6549cc3fc46b9ad68cbf4c50b162ce1013d4da817d05d1edf1f12fae",
+    "zh:74ff7f1610065e14c043cd9d74b3d5e0de4474f09a1a81e0b126b920b5cf6a27",
+    "zh:800e1b168149d507d23845f7a8b7e598c7dc16d2ee0f47848cf85d3e7458884f",
+    "zh:81ac3c68d6230b77740ca367e0c05a32ebb9be0fe5478c836573218a84eb3e46",
+    "zh:86536598796ba65539816f08351ac0ab32988ab84fa8f100049579996fafc800",
+    "zh:b9985c64f0f0b5bafb7067a60381fd807f7c3dd952c5d9f531385e464867bdd5",
+    "zh:c19c692896469724c6320fa7d87532ec3935e14e0e0fa0a8a0f1cf28ae7a0b0a",
+    "zh:cb8b14f246953a275ada562f5275a0d1a4938b7d20597e62fabe264012410f53",
+    "zh:cdbfa0ad87ff4d7451cfb89e53692a651d4c9cadece6845e60d986fd454b52b3",
+    "zh:ed5c4c8ae5adda37942bb15ef058c0811a95cb4c87259ae822627756dcb90efc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.1.2"
+  constraints = ">= 1.2.0"
+  hashes = [
+    "h1:UVuNjmuEM4ZVtItbh1QRGulkBWxDY929roxFQhEf9Ks=",
+    "zh:09bd2b6f33a040c3fd59d82c9768b886b8c82163e31ec92dc1b747229d0548df",
+    "zh:09f209fa57ad5d01f04c458f1719b42958ca5e0fc2eca63d9ec29f92c77a29f8",
+    "zh:0bfc627539500ffb2a41a2f8a5ea7f6fb1d76367b11bbf9489b483b9e8dfff8f",
+    "zh:0c0fef5587a5e927d15f9f4cc13cd0620b138238f9a422490fe9ea2bf086b61a",
+    "zh:187f99648fad2b84d49cdd372f8f6cedbf06e13411b3f1ff66708f66852d7855",
+    "zh:3d9ae08f8a99b19e80bd27708aecf592c28c92da66fd60189dfd7dce4d7da93c",
+    "zh:60b767109362c616b2e6386bfb08581b03bc3e528920444e52b16743f5a180d6",
+    "zh:729db42ed49d91c9b51eb602b9253e6ed6b3ab613c42deefc14996c9a8ee8ae4",
+    "zh:8401f3bf6d69ce43eb14911823c7e5cbb273cf564508043cd04fb064c30a3e1a",
+    "zh:91139b492ce1f41847017349ea49f9441b7cf70762c8d1c32a6a909e25ed10c1",
+    "zh:98fca606a539510edc94dcad8069a321e6a42df90e483f58df03b305726d9220",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.1.0"
+  constraints = ">= 1.11.0"
+  hashes = [
+    "h1:L/3XfqLQ4bS1PjH/FksJPm+MYIOxCwn97ozbfSwg/VQ=",
+    "zh:22e2bcef08fb7f97ed503a27e3725d9d14fdd09fe3aa144fae8a7f78ed27856a",
+    "zh:2380cc2a91239b80ea380af8a7fcdcc7396f5213a71a251a5505c962ac6cb9c2",
+    "zh:496ea2818d5480590ada763672be051f4e76dc12c6a61fde2faa0c909e174eb7",
+    "zh:4e5b6c230d9a8da8a0f12e5db198f158f2c26432ad8e1c6ac22770ce7ec39118",
+    "zh:55ad614beffda4cdc918ad87dca09bb7b961f12183c0923230301f73e23e9665",
+    "zh:6849c52899091fa2f6714d8e5180a4affffc4b2ad03dc2250043d4b32049e16e",
+    "zh:7a6f0d9da5172b3770af98d59263e142313a8b2c4048271893c6003493ad1c89",
+    "zh:7c97fb24e60c41fa16f6305620d18ae51545c329f46f92988493a4c51a4e43e5",
+    "zh:a08111c4898544c40c62437cc28798d1f4d7298f61ddaf3f48dddec042d3519f",
+    "zh:be7493bff6b9f95fe203c295bfc5933111e7c8a5f3bd9e9ae143a0d699d516f8",
+    "zh:e4c94adc65b5ad5551893f58c19e1c766f212f16220087ca3e940a89449ac285",
+  ]
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,4 @@
 config {
-  deep_check = false
   ignore_module = {}
   varfile = []
 }

--- a/README.md
+++ b/README.md
@@ -117,52 +117,72 @@ Here's the gist of using it directly from github.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12 |
-| helm | >= 1.2 |
-| kubernetes | >= 1.11.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.2 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
-| helm | >= 1.2 |
-| kubernetes | >= 1.11.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 1.2 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.11.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/namespace) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| app | A Release is an instance of a chart running in a Kubernetes cluster. | `map` | `{}` | no |
-| app\_deploy | Whether or not to deploy app | `bool` | `true` | no |
-| bucket | Backup and Restore bucket. | `string` | n/a | yes |
-| cluster\_name | Cluster name. | `string` | n/a | yes |
-| description | Namespace description | `string` | `"velero-back-up-and-restore"` | no |
-| iam\_deploy | Whether or not to deploy iam role | `bool` | `true` | no |
-| iam\_role\_name | Name of the Velero IAM role | `string` | `""` | no |
-| name | Namespace name | `string` | `"velero"` | no |
-| namespace\_deploy | Whether or not to deploy namespace | `bool` | `false` | no |
-| openid\_connect\_provider\_uri | OpenID Connect Provider for EKS to enable IRSA. | `string` | n/a | yes |
-| repository | VMware Tanzu repository for Helm repos. | `string` | `"https://vmware-tanzu.github.io/helm-charts"` | no |
-| tags | A mapping of tags to assign to the object. | `map` | `{}` | no |
-| values | List of values in raw yaml to pass to helm. Values will be merged. | `list(string)` | n/a | yes |
+| <a name="input_app"></a> [app](#input\_app) | A Release is an instance of a chart running in a Kubernetes cluster. | `map(any)` | `{}` | no |
+| <a name="input_app_deploy"></a> [app\_deploy](#input\_app\_deploy) | Whether or not to deploy app | `bool` | `true` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | Backup and Restore bucket. | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Cluster name. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Namespace description | `string` | `"velero-back-up-and-restore"` | no |
+| <a name="input_iam_deploy"></a> [iam\_deploy](#input\_iam\_deploy) | whther or not to deploy iam role | `bool` | `true` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the Velero IAM role | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | Installation name | `string` | `"velero"` | no |
+| <a name="input_namespace_deploy"></a> [namespace\_deploy](#input\_namespace\_deploy) | Whether or not to deploy namespace | `bool` | `false` | no |
+| <a name="input_namespace_name"></a> [namespace\_name](#input\_namespace\_name) | Kubernetes namespace name | `string` | `null` | no |
+| <a name="input_openid_connect_provider_uri"></a> [openid\_connect\_provider\_uri](#input\_openid\_connect\_provider\_uri) | OpenID Connect Provider for EKS to enable IRSA. | `string` | n/a | yes |
+| <a name="input_repository"></a> [repository](#input\_repository) | VMware Tanzu repository for Helm repos. | `string` | `"https://vmware-tanzu.github.io/helm-charts"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the object. | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged. | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| namespace\_name | Namespace name |
-
+| <a name="output_namespace_name"></a> [namespace\_name](#output\_namespace\_name) | Namespace name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Commands
 
 <!-- START makefile-doc -->
 ```
-$ make help
+$ make help 
+make[1]: Entering directory '/home/jay/dev/altitude-sports/terraform-kubernetes-velero'
 hooks                          Commit hooks setup
 validate                       Validate with pre-commit hooks
 changelog                      Update changelog
+make[1]: Leaving directory '/home/jay/dev/altitude-sports/terraform-kubernetes-velero' 
 ```
 <!-- END makefile-doc -->
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,4 @@
-data aws_iam_policy_document assume_role {
+data "aws_iam_policy_document" "assume_role" {
   statement {
     sid = "serviceaccount"
 
@@ -22,7 +22,7 @@ data aws_iam_policy_document assume_role {
   }
 }
 
-data aws_iam_policy_document policy {
+data "aws_iam_policy_document" "policy" {
   statement {
     sid = "ec2"
 
@@ -61,9 +61,9 @@ data aws_iam_policy_document policy {
   }
 }
 
-resource aws_iam_role this {
-  count              = var.iam_deploy ? 1 : 0
-  name               = var.iam_role_name == "" ? format("%s-%s", var.cluster_name, var.name) : var.iam_role_name
+resource "aws_iam_role" "this" {
+  count = var.iam_deploy ? 1 : 0
+  name  = var.iam_role_name == "" ? format("%s-%s", var.cluster_name, var.name) : var.iam_role_name
 
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags = merge(var.tags,
@@ -73,7 +73,7 @@ resource aws_iam_role this {
   )
 }
 
-resource aws_iam_role_policy this {
+resource "aws_iam_role_policy" "this" {
   count  = var.iam_deploy ? 1 : 0
   name   = format("%s-%s", var.cluster_name, var.name)
   role   = element(aws_iam_role.this.*.id, 0)

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  namespace  = data.kubernetes_namespace.this.metadata.0.name
-  account_id = data.aws_caller_identity.current.account_id
+  namespace_name = coalesce(var.namespace_name, var.name)
+  namespace      = data.kubernetes_namespace.this.metadata.0.name
+  account_id     = data.aws_caller_identity.current.account_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  namespace  = element(concat([for entry in kubernetes_namespace.this : entry.id], list("")), 0)
+  namespace  = element(concat([for entry in kubernetes_namespace.this : entry.id], tolist([])), 0)
   account_id = data.aws_caller_identity.current.account_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
   namespace_name = coalesce(var.namespace_name, var.name)
-  namespace      = data.kubernetes_namespace.this.metadata.0.name
+  namespace      = data.kubernetes_namespace.this.metadata[0].name
   account_id     = data.aws_caller_identity.current.account_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  namespace  = element(concat([for entry in kubernetes_namespace.this : entry.id], tolist([])), 0)
+  namespace  = data.kubernetes_namespace.this.metadata.0.name
   account_id = data.aws_caller_identity.current.account_id
 }

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,16 @@ resource "kubernetes_namespace" "this" {
   }
 }
 
+data "kubernetes_namespace" "this" {
+  metadata {
+    name = var.name
+  }
+
+  depends_on = [
+    kubernetes_namespace.this
+  ]
+}
+
 resource "helm_release" "this" {
   count = var.app_deploy ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ resource "kubernetes_namespace" "this" {
   }
 }
 
-// Retrieving this data will ensure that the target Kubernetes namespace exists
-// before proceeding
+# Retrieving this data will ensure that the target Kubernetes namespace exists
+# before proceeding.
 data "kubernetes_namespace" "this" {
   metadata {
     name = local.namespace_name

--- a/main.tf
+++ b/main.tf
@@ -2,22 +2,24 @@ resource "kubernetes_namespace" "this" {
   count = var.namespace_deploy ? 1 : 0
 
   metadata {
-    name = var.name
+    name = local.namespace_name
 
     labels = {
-      name        = var.name
+      name        = local.namespace_name
       description = var.description
     }
   }
 }
 
+// Retrieving this data will ensure that the target Kubernetes namespace exists
+// before proceeding
 data "kubernetes_namespace" "this" {
   metadata {
-    name = var.name
+    name = local.namespace_name
   }
 
   depends_on = [
-    kubernetes_namespace.this
+    kubernetes_namespace.this,
   ]
 }
 

--- a/value_templates/serviceaccount.template.yaml
+++ b/value_templates/serviceaccount.template.yaml
@@ -1,0 +1,5 @@
+serviceAccount:
+  server:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: '${EKS_ROLE_ARN}'

--- a/variables.tf
+++ b/variables.tf
@@ -28,9 +28,9 @@ variable "name" {
 }
 
 variable "namespace_name" {
-  description = "Kubernetes namespace name. If left unset, the `name` variable will be used instead."
+  default     = null
+  description = "Kubernetes namespace name"
   type        = string
-  optional    = true
 }
 
 variable "description" {

--- a/variables.tf
+++ b/variables.tf
@@ -23,8 +23,14 @@ variable "iam_deploy" {
 
 variable "name" {
   default     = "velero"
-  description = "Namespace name"
+  description = "Installation name"
   type        = string
+}
+
+variable "namespace_name" {
+  description = "Kubernetes namespace name. If left unset, the `name` variable will be used instead."
+  type        = string
+  optional    = true
 }
 
 variable "description" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    kubernetes = ">= 1.11.0"
+    aws        = ">= 3.0"
     helm       = ">= 1.2"
+    kubernetes = ">= 1.11.0"
   }
 }


### PR DESCRIPTION
* Replace calls to `list` function with new `tolist` function, as per the
  [Terraform docs](https://www.terraform.io/docs/language/functions/list.html)
* Move hardcoded `serviceAccount` values into a template YAML file

The motivation behind this change is that newer Terraform versions are throwing an exception when using this module:
```
Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
```

The [Terraform docs](https://www.terraform.io/docs/language/functions/list.html) provide an alternative to use in these cases.